### PR TITLE
feat: in-page explore facets, nav search-only, and filter UX polish

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -351,6 +351,8 @@ const { loadArea, setConfig, getMetadata } = await import(`${miloLibs}/utils/uti
 
   console.log('Injecting search into navigation. Target element:', topNav);
   const searchElement = document.createElement('blog-search');
+  searchElement.classList.add('nav-search');
+  searchElement.setAttribute('data-source', '/sorted-index/sorted-query-index.json');
 
   const nav = document.querySelector('.feds-nav');
   const navWrapper = document.querySelector('.feds-nav-wrapper');
@@ -383,6 +385,21 @@ const { loadArea, setConfig, getMetadata } = await import(`${miloLibs}/utils/uti
 
   moveSearch(mq);
   mq.addEventListener('change', moveSearch);
+
+  function injectExploreFacets() {
+    const articleFeed = document.querySelector('main .article-feed, main .article-feed-post-process');
+    if (!articleFeed || document.querySelector('blog-search.explore-facets')) return;
+
+    const exploreFacets = document.createElement('blog-search');
+    exploreFacets.classList.add('explore-facets');
+    exploreFacets.setAttribute('variant', 'explore');
+    const dataSource = searchElement.getAttribute('data-source');
+    exploreFacets.setAttribute('data-source', dataSource || '/sorted-index/sorted-query-index.json');
+
+    articleFeed.parentElement.insertBefore(exploreFacets, articleFeed);
+  }
+
+  injectExploreFacets();
 
   initSidekick();
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -387,6 +387,9 @@ const { loadArea, setConfig, getMetadata } = await import(`${miloLibs}/utils/uti
   mq.addEventListener('change', moveSearch);
 
   function injectExploreFacets() {
+    // Author pages show only that author's articles; facets/search don't apply there.
+    if (window.location.pathname.includes('/authors/')) return;
+
     const articleFeed = document.querySelector('main .article-feed, main .article-feed-post-process');
     if (!articleFeed || document.querySelector('blog-search.explore-facets')) return;
 

--- a/test/unit-tests/blog-search-facets.test.mjs
+++ b/test/unit-tests/blog-search-facets.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * unit tests for faceted filter functions
+ *
+ * tested methods: applyFilters, generateFacets, loadFiltersFromURL
+ *
+ * browser globals are set as minimal inert stubs to allow blog-search.js to load in Node
+ */
+
+globalThis.HTMLElement = class {};
+globalThis.window = { location: { search: '', pathname: '/' } };
+globalThis.customElements = { define: () => {} };
+
+const { default: BlogSearch } = await import('../../web-components/search/blog-search.js');
+import { expect } from 'chai';
+
+const applyFilters = (data, filters) => BlogSearch.prototype.applyFilters.call({}, data, filters);
+const generateFacets = (data) => BlogSearch.prototype.generateFacets.call({}, data);
+const loadFiltersFromURL = () => BlogSearch.prototype.loadFiltersFromURL.call({});
+
+const EMPTY_FILTERS = { cat: [], prod: [], author: [], date: [], type: [] };
+
+const ARTICLE_UXP = {
+  title: 'UXP Developer Guide',
+  tags: '["UXP","Developer Tools"]',
+  adobeCloud: 'Creative Cloud',
+  adobeApp: 'Photoshop',
+  author: 'Raymond Camden',
+  sortDate: '2024-06-01',
+  articleType: '',
+};
+
+const ARTICLE_FIREFLY = {
+  title: 'Firefly API Overview',
+  tags: '["Firefly","AI"]',
+  adobeCloud: 'Creative Cloud',
+  adobeApp: 'Firefly',
+  author: 'Ingo Eichel',
+  sortDate: '2024-03-15',
+  articleType: '',
+};
+
+const ARTICLE_AEM = {
+  title: 'AEM Headless Introduction',
+  tags: '["AEM","CMS"]',
+  adobeCloud: 'Experience Cloud',
+  adobeApp: 'AEM',
+  author: 'Raymond Camden',
+  sortDate: '2023-11-20',
+  articleType: '',
+};
+
+const ARTICLE_NO_TYPE = {
+  title: 'General Article',
+  tags: '["General"]',
+  adobeApp: 'Acrobat',
+  author: 'Test Author',
+  sortDate: '2023-01-01',
+};
+
+// T01: OR logic within a single filter group
+
+describe('T01 — applyFilters: OR within group', () => {
+  it('returns only articles tagged "UXP" or "Firefly", excludes all others', () => {
+    const data = [ARTICLE_UXP, ARTICLE_FIREFLY, ARTICLE_AEM];
+    const filters = { ...EMPTY_FILTERS, cat: ['UXP', 'Firefly'] };
+    const result = applyFilters(data, filters);
+    expect(result).to.have.length(2);
+    expect(result.map((a) => a.title)).to.include('UXP Developer Guide');
+    expect(result.map((a) => a.title)).to.include('Firefly API Overview');
+    expect(result.map((a) => a.title)).to.not.include('AEM Headless Introduction');
+  });
+});
+
+// T02: AND logic across filter groups
+
+describe('T02 — applyFilters: AND across groups', () => {
+  it('returns only articles matching both criteria (cat=UXP AND prod=AEM)', () => {
+    const data = [ARTICLE_UXP, ARTICLE_FIREFLY, ARTICLE_AEM];
+    const filters = { ...EMPTY_FILTERS, cat: ['UXP'], prod: ['AEM'] };
+    const result = applyFilters(data, filters);
+    expect(result).to.have.length(0);
+  });
+});
+
+// T03: Articles missing articleType field are handled gracefully
+
+describe('T03 — applyFilters: missing articleType fields', () => {
+  it('returns empty array when no article has articleType, throws no error', () => {
+    const data = [ARTICLE_UXP, ARTICLE_FIREFLY, ARTICLE_NO_TYPE];
+    const filters = { ...EMPTY_FILTERS, type: ['Tutorial'] };
+    let result;
+    expect(() => { result = applyFilters(data, filters); }).to.not.throw();
+    expect(result).to.deep.equal([]);
+  });
+});
+
+// T04: generateFacets: structure and deduplication
+
+describe('T04 — generateFacets: structure, uniqueness, correct groups', () => {
+  it('returns object with unique values per group and no duplicates', () => {
+    const data = [ARTICLE_UXP, ARTICLE_FIREFLY, ARTICLE_AEM];
+    const facets = generateFacets(data);
+
+    expect(facets).to.have.all.keys('cat', 'prod', 'author', 'date', 'type');
+    expect(facets.author.filter((a) => a === 'Raymond Camden')).to.have.length(1);
+    expect(facets.prod.filter((p) => p === 'Creative Cloud')).to.have.length(1);
+    expect(facets.author).to.include('Ingo Eichel');
+  });
+});
+
+// T05: loadFiltersFromURL: reads URL params into correct groups
+
+describe('T05 — loadFiltersFromURL: reads URL parameters correctly', () => {
+  afterEach(() => {
+    globalThis.window.location.search = '';
+  });
+
+  it('returns { cat: ["UXP", "Firefly"] } for URL ?cat=UXP&cat=Firefly', () => {
+    globalThis.window.location.search = '?cat=UXP&cat=Firefly';
+    const filters = loadFiltersFromURL();
+    expect(filters.cat).to.deep.equal(['UXP', 'Firefly']);
+    expect(filters.prod).to.deep.equal([]);
+    expect(filters.author).to.deep.equal([]);
+  });
+});

--- a/test/unit-tests/blog-search-filter-data.test.mjs
+++ b/test/unit-tests/blog-search-filter-data.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for filterData (blog search ranking over query-index rows).
+ * Logic lives in web-components/search/blog-search-filter-data.js (imported by blog-search.js).
+ */
+import filterData from '../../web-components/search/blog-search-filter-data.js';
+import { expect } from 'chai';
+
+describe('filterData (blog-search)', () => {
+  const sample = [
+    {
+      title: 'Creative Cloud Updates',
+      description: 'Monthly news for subscribers',
+      path: '/en/publish/2024/creative-cloud-updates',
+    },
+    {
+      title: 'Photoshop Tips',
+      description: 'Creative workflows',
+      path: '/en/publish/2024/photoshop-tips',
+    },
+    {
+      title: 'Unrelated',
+      description: 'Nothing here',
+      path: '/en/publish/2024/other',
+    },
+  ];
+
+  it('returns empty array when nothing matches', () => {
+    expect(filterData(['zzzmissing'], sample)).to.deep.equal([]);
+  });
+
+  it('finds articles whose title contains the full phrase (exact tier)', () => {
+    const out = filterData(['creative', 'cloud'], sample);
+    expect(out.map((r) => r.title)).to.include('Creative Cloud Updates');
+  });
+
+  it('matches fuzzy terms in title when full phrase is not contiguous', () => {
+    const out = filterData(['photoshop'], sample);
+    expect(out.some((r) => r.title === 'Photoshop Tips')).to.equal(true);
+  });
+
+  it('deduplicates by title, keeping best-ranked hit once', () => {
+    const dup = [
+      { title: 'Same Title', description: 'a', path: '/en/publish/a' },
+      { title: 'Same Title', description: 'b', path: '/en/publish/b' },
+    ];
+    const out = filterData(['same'], dup);
+    expect(out).to.have.length(1);
+    expect(out[0].title).to.equal('Same Title');
+  });
+});

--- a/web-components/search/blog-search-filter-data.js
+++ b/web-components/search/blog-search-filter-data.js
@@ -1,0 +1,79 @@
+/**
+ * Pure search ranking over query-index rows (no DOM / no fetch).
+ * Used by blog-search.js and unit-tested in Node.
+ */
+
+function filterData(searchTerms, data) {
+  const fullPhrase = searchTerms.join(' ');
+  const exactMatches = [];
+  const phraseMatches = [];
+  const foundInHeader = [];
+  const foundInMeta = [];
+
+  data.forEach((result) => {
+    const title = (result.header || result.title).toLowerCase();
+    const metaContents = `${result.title} ${result.description} ${result.path.split('/').pop()}`.toLowerCase();
+
+    if (title.includes(fullPhrase)) {
+      exactMatches.push({ minIdx: title.indexOf(fullPhrase), result });
+      return;
+    }
+
+    if (metaContents.includes(fullPhrase)) {
+      phraseMatches.push({ minIdx: metaContents.indexOf(fullPhrase), result });
+      return;
+    }
+
+    let minIdx = -1;
+    let matchCount = 0;
+
+    searchTerms.forEach((term) => {
+      const idx = title.indexOf(term);
+      if (idx >= 0) {
+        matchCount += 1;
+        if (minIdx === -1 || idx < minIdx) minIdx = idx;
+      }
+    });
+
+    if (minIdx >= 0) {
+      foundInHeader.push({ minIdx, result, matchCount });
+      return;
+    }
+
+    minIdx = -1;
+    matchCount = 0;
+
+    searchTerms.forEach((term) => {
+      const idx = metaContents.indexOf(term);
+      if (idx >= 0) {
+        matchCount += 1;
+        if (minIdx === -1 || idx < minIdx) minIdx = idx;
+      }
+    });
+
+    if (minIdx >= 0) {
+      foundInMeta.push({ minIdx, result, matchCount });
+    }
+  });
+  const sorted = [
+    ...exactMatches.sort((a, b) => a.minIdx - b.minIdx),
+    ...phraseMatches.sort((a, b) => a.minIdx - b.minIdx),
+    ...foundInHeader.sort((a, b) => b.matchCount - a.matchCount || a.minIdx - b.minIdx),
+    ...foundInMeta.sort((a, b) => b.matchCount - a.matchCount || a.minIdx - b.minIdx),
+  ];
+
+  const seen = new Set();
+  const uniqueResults = [];
+
+  sorted.forEach((item) => {
+    const key = item.result.title.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      uniqueResults.push(item.result);
+    }
+  });
+
+  return uniqueResults;
+}
+
+export default filterData;

--- a/web-components/search/blog-search.css
+++ b/web-components/search/blog-search.css
@@ -84,7 +84,7 @@ blog-search .search-box {
 /* nav variant - always visible search bar in header */
 :host(.nav-search) {
   position: relative;
-  padding: 0px 8px;
+  padding: 0 8px;
   margin-left: auto; /* Push to right side of nav */
   display: flex;
   align-items: center;
@@ -141,7 +141,7 @@ header nav.has-blog-nav-search {
   outline: none;
   border-color: #0265dc;
   background-color: #fff;
-  box-shadow: 0 0 0 2px rgba(2, 101, 220, 0.1);
+  box-shadow: 0 0 0 2px rgb(2 101 220 / 10%);
 }
 
 /* Search results positioning from Shadow DOM */
@@ -149,21 +149,20 @@ header nav.has-blog-nav-search {
   display: grid;
   grid-template-columns: repeat(4, minmax(260px, 1fr));
   grid-auto-rows: auto;
-  grid-column-gap: 20px;
-  grid-row-gap: 20px;
+  gap: 20px;
   position: fixed;
-  top: var(--nav-height, 64px);
+  top: calc(var(--nav-height, 64px) + 48px);
   left: 50%;
   transform: translateX(-50%);
   width: 100%;
   max-width: 1437px;
-  max-height: calc(100vh - var(--nav-height, 64px));
+  max-height: calc(100vh - var(--nav-height, 64px) - 48px);
   overflow-y: auto;
   background: white;
   border: 1px solid #ddd;
   border-top: none;
   border-radius: 0 0 4px 4px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 15%);
   z-index: 1001;
   padding: 20px;
   list-style: none;
@@ -240,8 +239,8 @@ header nav.has-blog-nav-search {
   text-decoration: none;
   justify-content: flex-start;
   box-sizing: border-box;
-  box-shadow: 4px 4px 4px 4px rgba(0, 0, 0, 0.1);
-  padding: 5px 5px 24px 5px;
+  box-shadow: 4px 4px 4px 4px rgb(0 0 0 / 10%);
+  padding: 5px 5px 24px;
   overflow: hidden;
 }
 
@@ -251,6 +250,7 @@ header nav.has-blog-nav-search {
   margin-top: 10px;
   padding: 0 16px;
   text-transform: uppercase;
+
   /* left: 16px; */
   letter-spacing: .1em;
 }
@@ -281,6 +281,7 @@ header nav.has-blog-nav-search {
 
 .nav-search-container .search-results > li p {
   font-size: var(--body-font-size-s);
+  /* stylelint-disable-next-line value-no-vendor-prefix */
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
@@ -303,6 +304,493 @@ header nav.has-blog-nav-search {
   object-fit: cover;
   width: 100%;
   height: 100%;
+}
+
+/* ── Explore facets (in-page, below page title) ── */
+:host(.explore-facets) {
+  display: block;
+  width: 100%;
+  max-width: var(--grid-width, 1200px);
+  margin: 0 auto 24px;
+  padding: 0 20px;
+  box-sizing: border-box;
+}
+
+.explore-toolbar {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  gap: 12px 16px;
+  padding: 12px 0 16px;
+  border-bottom: 1px solid #e8e8e8;
+}
+
+.explore-filters-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #222;
+  flex-shrink: 0;
+}
+
+.explore-toolbar .filter-chips {
+  flex: 1 1 100%;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.explore-search {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.explore-search-trigger {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  padding: 6px;
+  border-radius: 50%;
+}
+
+.explore-search-trigger:hover {
+  background: #f0f0f0;
+}
+
+.explore-search-input {
+  width: 0;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  opacity: 0;
+  transition: width 0.2s ease, opacity 0.2s ease;
+}
+
+.explore-search.expanded .explore-search-input {
+  width: 220px;
+  min-width: 180px;
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  opacity: 1;
+}
+
+.explore-search.expanded .explore-search-input:focus {
+  outline: none;
+  border-color: #0265dc;
+  box-shadow: 0 0 0 2px rgb(2 101 220 / 10%);
+}
+
+.filter-bar-explore {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  gap: 8px;
+  position: static;
+  flex: 1 1 auto;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  z-index: auto;
+  overflow: visible;
+}
+
+.filter-bar-explore .filter-dropdown,
+.filter-bar-explore .filter-date-select {
+  flex-shrink: 0;
+}
+
+.filter-bar-explore .filter-date-select {
+  margin-right: 4px;
+  appearance: none;
+  height: 32px;
+  padding: 0 30px 0 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #fff;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="%23555" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  font-size: 13px;
+  line-height: 30px;
+  cursor: pointer;
+  color: #333;
+}
+
+.filter-bar-explore .filter-date-select:focus {
+  outline: none;
+  border-color: #ccc;
+}
+
+.filter-bar-explore .filter-dropdown-toggle {
+  height: 32px;
+  padding: 0 30px 0 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #fff;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="%23555" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  text-align: left;
+}
+
+.filter-bar-explore .filter-dropdown ul {
+  top: calc(100% + 8px);
+}
+
+.filter-dropdown-toggle.has-active {
+  border-color: #0265dc;
+  color: #0265dc;
+  font-weight: 600;
+}
+
+.explore-clear-all {
+  flex-shrink: 0;
+}
+
+.explore-results {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 32px 32px;
+  list-style: none;
+  margin: 24px auto 0;
+  padding: 0;
+  max-width: 1200px;
+}
+
+.explore-results > li {
+  border: 1px solid var(--color-gray-200, #e8e8e8);
+  border-radius: 4px;
+  overflow: hidden;
+  min-width: 0;
+  margin: 0;
+}
+
+.explore-results > li > a {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  text-decoration: none;
+  color: inherit;
+  text-align: left;
+  box-sizing: border-box;
+}
+
+.explore-results .search-result-image {
+  width: 100%;
+  height: 215px;
+  line-height: 0;
+  overflow: hidden;
+  background-color: transparent;
+  border-radius: 4px 4px 0 0;
+  flex-shrink: 0;
+}
+
+.explore-results .search-result-image img,
+.explore-results .search-result-image picture img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 4px 4px 0 0;
+}
+
+.explore-results .search-result-tags,
+.explore-results .search-result-tag {
+  display: block;
+  margin: 0 2rem 0.5rem;
+  padding: 0;
+  font-weight: var(--type-detail-all-weight, 600);
+  color: var(--color-gray-600, #6e6e6e);
+  font-size: var(--type-detail-s-size, 12px);
+  line-height: var(--detail-line-height, 1.25);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.explore-results .search-result-image + .search-result-tags,
+.explore-results .search-result-image + .search-result-tag,
+.explore-results .search-result-image + .search-result-title {
+  margin-top: 2rem;
+}
+
+.explore-results > li > a:not(:has(.search-result-image)) > :is(
+  .search-result-tags,
+  .search-result-tag,
+  .search-result-title
+):first-child {
+  margin-top: 2rem;
+}
+
+.explore-results .search-result-title {
+  margin: 0 2rem 5px;
+  padding: 0;
+  font-size: var(--heading-font-size-xs, 18px);
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.explore-results .search-result-title a {
+  color: var(--text-color, #000);
+  text-decoration: none;
+}
+
+@media (min-width: 600px) {
+  .explore-results .search-result-title {
+    font-size: var(--heading-font-size-s, 20px);
+    min-height: 4.7rem;
+  }
+}
+
+.explore-results > li > a > p:not(.search-result-date) {
+  margin: 0 2rem 1rem;
+  padding: 0;
+  color: var(--color-gray-700, #505050);
+  font-size: var(--type-detail-m-size, 14px);
+  font-weight: 400;
+  line-height: 1.5;
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-height: 3.36rem;
+  flex: 1;
+}
+
+.explore-results .search-result-date {
+  margin: auto 2rem 0;
+  padding: 0 0 2rem;
+  font-weight: var(--type-detail-all-weight, 600);
+  color: var(--color-gray-600, #6e6e6e);
+  font-size: var(--type-detail-s-size, 12px);
+  line-height: var(--detail-line-height, 1.25);
+  letter-spacing: 0.1em;
+  text-transform: none;
+}
+
+.explore-results.no-results {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 160px;
+  margin-top: 32px;
+}
+
+.explore-results.no-results > li.explore-no-results-message {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 24px 16px;
+  text-align: center;
+  max-width: 28rem;
+}
+
+.explore-no-results-title {
+  margin: 0 0 8px;
+  font-size: 15px;
+  line-height: 1.5;
+  color: #333;
+  font-weight: 600;
+}
+
+.explore-no-results-hint {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #6e6e6e;
+}
+
+@media (max-width: 900px) {
+  .explore-results {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .explore-results {
+    grid-template-columns: 1fr;
+  }
+
+  .explore-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .filter-bar-explore {
+    flex-wrap: wrap;
+  }
+}
+
+/* ── Filter Bar (horizontal, legacy fixed — non-explore only) ── */
+.filter-bar:not(.filter-bar-explore) {
+  position: fixed;
+  top: var(--nav-height, 64px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  padding: 8px 20px;
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 8px;
+  align-items: center;
+  overflow: visible;
+  z-index: 1002;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 6%);
+}
+
+/* ── Dropdowns ── */
+.filter-dropdown {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.filter-dropdown-toggle {
+  padding: 5px 12px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  color: #333;
+}
+
+.filter-dropdown-toggle:hover,
+.filter-dropdown-toggle[aria-expanded="true"] {
+  border-color: #0265dc;
+  color: #0265dc;
+}
+
+.filter-dropdown ul {
+  display: none;
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 220px;
+  width: max-content;
+  max-width: 360px;
+  max-height: 280px;
+  overflow-y: auto;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+  padding: 6px 0;
+  margin: 0;
+  list-style: none;
+  z-index: 1010;
+}
+
+.filter-dropdown ul.show {
+  display: block;
+}
+
+.filter-dropdown ul li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 18px;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.filter-dropdown ul li label {
+  flex: 1;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.filter-dropdown ul li:hover {
+  background: #f5f5f5;
+}
+
+.filter-count {
+  color: #888;
+  font-size: 12px;
+}
+
+/* ── Date select ── */
+.filter-bar select {
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fff;
+  font-size: 13px;
+  cursor: pointer;
+  color: #333;
+}
+
+/* ── Chips ── */
+.filter-chips {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 6px;
+  align-items: center;
+  overflow-x: auto;
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: #e8f0fe;
+  border: 1px solid #0265dc;
+  border-radius: 20px;
+  font-size: 12px;
+  color: #0265dc;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.filter-chip-remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 13px;
+  color: #0265dc;
+  padding: 0;
+  line-height: 1;
+}
+
+.filter-clear-all {
+  padding: 4px 10px;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  background: #fff;
+  font-size: 12px;
+  cursor: pointer;
+  color: #555;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.filter-clear-all:hover {
+  border-color: #c00;
+  color: #c00;
+}
+
+@media (max-width: 600px) {
+  .filter-bar:not(.filter-bar-explore) {
+    display: none;
+  }
+}
+
+.explore-facets-suppressed {
+  display: none !important;
 }
 
 /* No results styling */

--- a/web-components/search/blog-search.css
+++ b/web-components/search/blog-search.css
@@ -376,12 +376,6 @@ header nav.has-blog-nav-search {
   opacity: 1;
 }
 
-.explore-search.expanded .explore-search-input:focus {
-  outline: none;
-  border-color: #0265dc;
-  box-shadow: 0 0 0 2px rgb(2 101 220 / 10%);
-}
-
 .filter-bar-explore {
   display: flex;
   flex-flow: row nowrap;
@@ -403,8 +397,9 @@ header nav.has-blog-nav-search {
   flex-shrink: 0;
 }
 
+/* Match the date select to the toggle buttons (same height, font, rounded box)
+   and draw a custom chevron so spacing/alignment is consistent. */
 .filter-bar-explore .filter-date-select {
-  margin-right: 4px;
   appearance: none;
   height: 32px;
   padding: 0 30px 0 12px;
@@ -420,25 +415,8 @@ header nav.has-blog-nav-search {
   color: #333;
 }
 
-.filter-bar-explore .filter-date-select:focus {
-  outline: none;
-  border-color: #ccc;
-}
-
 .filter-bar-explore .filter-dropdown-toggle {
   height: 32px;
-  padding: 0 30px 0 12px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  background-color: #fff;
-  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="%23555" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>');
-  background-repeat: no-repeat;
-  background-position: right 10px center;
-  text-align: left;
-}
-
-.filter-bar-explore .filter-dropdown ul {
-  top: calc(100% + 8px);
 }
 
 .filter-dropdown-toggle.has-active {
@@ -594,22 +572,10 @@ header nav.has-blog-nav-search {
   box-shadow: none;
   padding: 24px 16px;
   text-align: center;
-  max-width: 28rem;
-}
-
-.explore-no-results-title {
-  margin: 0 0 8px;
   font-size: 15px;
   line-height: 1.5;
-  color: #333;
-  font-weight: 600;
-}
-
-.explore-no-results-hint {
-  margin: 0;
-  font-size: 14px;
-  line-height: 1.5;
   color: #6e6e6e;
+  max-width: 28rem;
 }
 
 @media (max-width: 900px) {
@@ -708,7 +674,6 @@ header nav.has-blog-nav-search {
 }
 
 .filter-dropdown ul li label {
-  flex: 1;
   white-space: nowrap;
   cursor: pointer;
 }

--- a/web-components/search/blog-search.js
+++ b/web-components/search/blog-search.js
@@ -977,10 +977,13 @@ class BlogSearch extends HTMLElement {
         author: 'Author',
         type: 'Type',
       };
-    const exploreGroups = new Set(['prod', 'cloud', 'cat', 'type', 'author', 'date']);
-    const facetEntries = explore
-      ? ['prod', 'cloud', 'cat', 'type', 'author', 'date'].map((group) => [group, facets[group]])
-      : Object.entries(facets);
+    // Date filter is disabled for now (not enough content); re-add 'date' to
+    // these arrays to bring it back.
+    const exploreGroups = new Set(['cloud', 'prod', 'cat', 'type', 'author']);
+    const order = explore
+      ? ['cloud', 'prod', 'cat', 'type', 'author']
+      : ['cat', 'cloud', 'prod', 'author', 'type'];
+    const facetEntries = order.map((group) => [group, facets[group]]);
 
     facetEntries.forEach(([group, values]) => {
       if (group === 'date') {

--- a/web-components/search/blog-search.js
+++ b/web-components/search/blog-search.js
@@ -1,8 +1,11 @@
 import { getLibs } from '../../scripts/devblog/devblog.js';
+import filterData from './blog-search-filter-data.js';
 import { wrapWithPlayOverlay } from '../../scripts/utils.js';
 
 // These will be loaded dynamically in the functions that need them
-let createOptimizedPicture, decorateIcons, fetchPlaceholders;
+let createOptimizedPicture;
+let decorateIcons;
+let fetchPlaceholders;
 let currentRenderId = 0;
 let searchDebounceTimer;
 
@@ -12,13 +15,73 @@ async function loadMiloUtils() {
     const utils = await import(`${miloLibs}/utils/utils.js`);
     createOptimizedPicture = utils.createOptimizedPicture;
     decorateIcons = utils.decorateIcons;
-    
+
     // Try to get fetchPlaceholders, fallback to empty function
     fetchPlaceholders = utils.fetchPlaceholders || (() => Promise.resolve({}));
   }
 }
 
 const searchParams = new URLSearchParams(window.location.search);
+const DEFAULT_INDEX_SOURCE = '/sorted-index/sorted-query-index.json';
+
+function parseDateToTimestamp(dateStr) {
+  if (!dateStr || typeof dateStr !== 'string') return 0;
+
+  const match = dateStr.trim().match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!match) return 0;
+
+  const ms = Date.UTC(
+    parseInt(match[1], 10),
+    parseInt(match[2], 10) - 1,
+    parseInt(match[3], 10),
+  );
+
+  return Math.floor(ms / 1000);
+}
+
+function getArticleSortTimestamp(article) {
+  if (article.updatedDate) {
+    const updatedTs = parseDateToTimestamp(article.updatedDate);
+    if (updatedTs !== 0) return updatedTs;
+  }
+
+  if (article.sortDateTimestamp != null && !Number.isNaN(article.sortDateTimestamp)) {
+    return parseInt(article.sortDateTimestamp, 10);
+  }
+
+  if (article.sortDate) {
+    return parseDateToTimestamp(article.sortDate);
+  }
+
+  return 0;
+}
+
+function comparePathNumbers(a, b) {
+  const numbersA = a.match(/\d+/g)?.map(Number) || [];
+  const numbersB = b.match(/\d+/g)?.map(Number) || [];
+  const maxLength = Math.max(numbersA.length, numbersB.length);
+
+  for (let i = 0; i < maxLength; i += 1) {
+    const numA = numbersA[i] || 0;
+    const numB = numbersB[i] || 0;
+    if (numA !== numB) return numB - numA;
+  }
+
+  return 0;
+}
+
+function sortArticlesByPublicationDate(articles) {
+  return [...articles].sort((a, b) => {
+    const tsA = getArticleSortTimestamp(a);
+    const tsB = getArticleSortTimestamp(b);
+
+    if (tsA !== 0 && tsB !== 0) return tsB - tsA;
+    if (tsA !== 0) return -1;
+    if (tsB !== 0) return 1;
+
+    return comparePathNumbers(a.path, b.path);
+  });
+}
 
 function findNextHeading(el) {
   let preceedingEl = el.parentElement.previousElement || el.parentElement.parentElement;
@@ -79,25 +142,55 @@ function highlightTextElements(terms, elements) {
   });
 }
 
-export async function fetchData(source) {
-  const response = await fetch(source);
+// eslint-disable-next-line no-console
+const logError = (ctx, msg, err = null) => console.error(`[blog-search][${new Date().toISOString()}] ${ctx}: ${msg}`, err || '');
+
+async function fetchData(source) {
+  let response;
+  try {
+    response = await fetch(source);
+  } catch (err) {
+    logError('fetchData', `network error fetching ${source}`, err);
+    return null;
+  }
   if (!response.ok) {
-    // eslint-disable-next-line no-console
-    console.error('error loading API response', response);
+    logError('fetchData', 'non-2xx response', response);
     return null;
   }
 
   const json = await response.json();
   if (!json) {
-    // eslint-disable-next-line no-console
-    console.error('empty API response', source);
+    logError('fetchData', `empty response from ${source}`);
     return null;
   }
 
   return json.data;
 }
 
-async function renderResult(result, searchTerms, titleTag) {
+function formatLongMonthDate(date) {
+  if (!date) return '';
+
+  const [year, month, day] = date.split('-');
+  const jsDate = new Date(Date.UTC(year, month - 1, day));
+
+  return jsDate.toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+function formatArticleCardDate(sortDate, updatedDate) {
+  if (updatedDate && sortDate) {
+    return `${formatLongMonthDate(updatedDate)} • First published ${formatLongMonthDate(sortDate)}`;
+  }
+  if (sortDate) return formatLongMonthDate(sortDate);
+  if (updatedDate) return formatLongMonthDate(updatedDate);
+  return '';
+}
+
+async function renderResult(result, searchTerms, titleTag, { showDate = false } = {}) {
   await loadMiloUtils();
   const li = document.createElement('li');
   const a = document.createElement('a');
@@ -169,16 +262,28 @@ async function renderResult(result, searchTerms, titleTag) {
     highlightTextElements(searchTerms, [description]);
     a.append(description);
   }
+  if (showDate) {
+    const dateDisplay = formatArticleCardDate(result.sortDate, result.updatedDate);
+    if (dateDisplay) {
+      const dateElement = document.createElement('p');
+      dateElement.className = 'search-result-date';
+      dateElement.textContent = dateDisplay;
+      a.append(dateElement);
+    }
+  }
   li.append(a);
   return li;
 }
-  
+
 function clearSearchResults(component) {
-  // looks for the results in theshadow dom first else it will fallback to the light dom
-  let searchResults = component.shadowRoot?.querySelector('.search-results') || component.querySelector('.search-results');
+  const searchResults = getSearchResultsEl(component);
   if (searchResults) {
     searchResults.innerHTML = '';
   }
+}
+
+function getSearchResultsEl(component) {
+  return component.shadowRoot?.querySelector('.search-results') || component.querySelector('.search-results');
 }
 
 function clearSearch(component) {
@@ -191,119 +296,82 @@ function clearSearch(component) {
   }
 }
 
-async function renderResults(component, config, filteredData, searchTerms) {
-  const renderId = ++currentRenderId;
+function exploreResultsContainer(component) {
+  const grid = document.createElement('ul');
+  grid.className = 'explore-results';
+  grid.dataset.h = findNextHeading(component);
+  return grid;
+}
 
-  clearSearchResults(component);
-  // looks for the results in theshadow dom first else it will fallback to the light dom
-  let searchResults = component.shadowRoot?.querySelector('.search-results') || component.querySelector('.search-results');
+async function renderExploreResults(component, config, filteredData, searchTerms) {
+  currentRenderId += 1;
+  const renderId = currentRenderId;
+
+  const exploreResults = component.shadowRoot?.querySelector('.explore-results');
+  if (!exploreResults) return;
+
+  const headingTag = exploreResults.dataset.h;
+
+  if (filteredData.length) {
+    const dateOpts = { showDate: true };
+    const results = await Promise.all(
+      filteredData.map((result) => renderResult(result, searchTerms, headingTag, dateOpts)),
+    );
+    if (renderId !== currentRenderId) return;
+
+    exploreResults.classList.remove('no-results');
+    exploreResults.replaceChildren(...results);
+  } else {
+    if (renderId !== currentRenderId) return;
+
+    const noResultsMessage = document.createElement('li');
+    noResultsMessage.className = 'explore-no-results-message';
+    noResultsMessage.setAttribute('role', 'status');
+
+    const noResultsTitle = document.createElement('p');
+    noResultsTitle.className = 'explore-no-results-title';
+    noResultsTitle.textContent = config.placeholders.searchNoResults || 'No results found.';
+
+    const noResultsHint = document.createElement('p');
+    noResultsHint.className = 'explore-no-results-hint';
+    noResultsHint.textContent = 'Try a different search term or adjust your filter selection.';
+
+    noResultsMessage.append(noResultsTitle, noResultsHint);
+    exploreResults.classList.add('no-results');
+    exploreResults.replaceChildren(noResultsMessage);
+  }
+}
+
+async function renderResults(component, config, filteredData, searchTerms) {
+  currentRenderId += 1;
+  const renderId = currentRenderId;
+
+  const searchResults = getSearchResultsEl(component);
   if (!searchResults) return;
 
   const headingTag = searchResults.dataset.h;
 
   if (filteredData.length) {
-    searchResults.classList.remove('no-results');
-    
-    // Render all results in parallel
     const results = await Promise.all(
-      filteredData.map(result => renderResult(result, searchTerms, headingTag))
+      filteredData.map((result) => renderResult(result, searchTerms, headingTag)),
     );
-    
-    // Check if this render is still current (not cancelled by a newer search)
-    if (renderId !== currentRenderId) return;  // ← ADD THIS CHECK
-    
-    // Append all results at once
-    results.forEach(li => searchResults.append(li));
+
+    if (renderId !== currentRenderId) return;
+
+    searchResults.classList.remove('no-results');
+    // replaceChildren avoids a paint frame where :empty hides the panel (display: none)
+    searchResults.replaceChildren(...results);
   } else {
-    if (renderId !== currentRenderId) return;  // ← ADD THIS CHECK ALSO
+    if (renderId !== currentRenderId) return;
 
     const noResultsMessage = document.createElement('li');
-    searchResults.classList.add('no-results');
     noResultsMessage.textContent = config.placeholders.searchNoResults || 'No results found.';
-    searchResults.append(noResultsMessage);
+    searchResults.classList.add('no-results');
+    searchResults.replaceChildren(noResultsMessage);
   }
 }
 
-function compareFound(hit1, hit2) {
-  return hit1.minIdx - hit2.minIdx;
-}
-
-// Write documentation for the updated version of the filter function later
-
-function filterData(searchTerms, data) {
-  const fullPhrase = searchTerms.join(' ');
-  const exactMatches = [];
-  const phraseMatches = [];
-  const foundInHeader = [];
-  const foundInMeta = [];
-
-  data.forEach((result) => {
-    const title = (result.header || result.title).toLowerCase();
-    const metaContents = `${result.title} ${result.description} ${result.path.split('/').pop()}`.toLowerCase();
-
-    if (title.includes(fullPhrase)) {
-      exactMatches.push({minIdx: title.indexOf(fullPhrase), result});
-      return;
-    }
-
-    if (metaContents.includes(fullPhrase)) {
-      phraseMatches.push({minIdx: metaContents.indexOf(fullPhrase), result});
-      return;
-    }
-
-    let minIdx = -1;
-    let matchCount = 0;
-
-    searchTerms.forEach((term) => {
-      const idx = title.indexOf(term);
-      if (idx >= 0) {
-        matchCount++;
-        if (minIdx === -1 || idx < minIdx) minIdx = idx;
-      }
-    });
-
-    if (minIdx >= 0) {
-      foundInHeader.push({minIdx, result, matchCount });
-      return;
-    }
-
-    minIdx = -1;
-    matchCount = 0;
-
-    searchTerms.forEach((term) => {
-      const idx = metaContents.indexOf(term);
-      if (idx >= 0) {
-        matchCount++;
-        if (minIdx === -1 || idx < minIdx) minIdx = idx;
-      }
-    });
-
-    if (minIdx >= 0) {
-      foundInMeta.push({minIdx, result, matchCount });
-    }
-  });
-  // First, sort everything
-  const sorted = [
-    ...exactMatches.sort((a, b) => a.minIdx - b.minIdx),
-    ...phraseMatches.sort((a, b) => a.minIdx - b.minIdx),
-    ...foundInHeader.sort((a, b) => b.matchCount - a.matchCount || a.minIdx - b.minIdx),
-    ...foundInMeta.sort((a, b) => b.matchCount - a.matchCount || a.minIdx - b.minIdx),
-  ];
-
-  // Then deduplicate by title, keeping first occurrence (best ranked)
-  const seen = new Set();
-  const uniqueResults = [];
-  
-  sorted.forEach(item => {
-    const key = item.result.title.toLowerCase();  // Note: item.result.title, not item.title
-    if (!seen.has(key)) {
-      seen.add(key);
-      uniqueResults.push(item.result);  // Push the actual result, not the wrapper
-    }
-  });
-  
-  return uniqueResults;
-}
+// filterData: see ./blog-search-filter-data.js (unit-tested in Node)
 
 const topicMatch = window.location.pathname.match(/\/topics\/([^/?]+)/);
 const currentTopic = topicMatch ? topicMatch[1] : null;
@@ -318,6 +386,11 @@ async function handleSearch(e, component, config) {
     window.history.replaceState({}, '', url.toString());
   }
 
+  if (component.classList.contains('explore-facets')) {
+    await component.refreshExploreView();
+    return;
+  }
+
   if (searchValue.length < 3) {
     clearSearch(component);
     return;
@@ -326,7 +399,13 @@ async function handleSearch(e, component, config) {
   const searchTerms = searchValue.toLowerCase().split(/\s+/).filter((term) => term.length >= 3);
 
   try {
-    const data = await fetchData(config.source);
+    let data = component.searchIndexData;
+    if (!data) {
+      data = await fetchData(config.source);
+      if (data) component.searchIndexData = data;
+    }
+    if (!data) return;
+
     let scopedData = data;
 
     if (currentTopic) {
@@ -342,9 +421,10 @@ async function handleSearch(e, component, config) {
     }
 
     const filteredData = filterData(searchTerms, scopedData);
-    await renderResults(component, config, filteredData, searchTerms);
+    const facetFilteredData = component.applyFilters(filteredData, component.activeFilters);
+    await renderResults(component, config, facetFilteredData, searchTerms);
   } catch (error) {
-    console.error('Error in handleSearch:', error);
+    logError('handleSearch', error.message, error);
   }
 }
 
@@ -365,7 +445,7 @@ function searchInput(component, config) {
   input.setAttribute('aria-label', searchPlaceholder);
 
   input.addEventListener('input', (e) => {
-    const currentTarget = e.target;  // Capture the input element reference
+    const currentTarget = e.target; // Capture the input element reference
     clearTimeout(searchDebounceTimer);
     searchDebounceTimer = setTimeout(() => {
       // Create a fake event object with the target
@@ -419,56 +499,141 @@ function searchBox(component, config) {
 
   return box;
 }
-  
+
+/**
+ * @typedef {Object} ActiveFilters
+ * @property {string[]} cat
+ * @property {string[]} prod
+ * @property {string[]} author
+ * @property {string[]} date
+ * @property {string[]} type
+ */
+
 class BlogSearch extends HTMLElement {
-  async connectedCallback() {               // expected to be synchronous (should not be asynchronous)
+  constructor() {
+    super();
+    this.activeFilters = {
+      cat: [],
+      prod: [],
+      author: [],
+      date: [],
+      type: [],
+    };
+  }
+
+  // Note: async connectedCallback is valid; the browser awaits the returned promise.
+  async connectedCallback() {
     // shadow dom gets created first
     this.attachShadow({ mode: 'open' });
-    
+
     if (searchParams.get('q')) {
       searchParams.delete('q');
       if (window.history.replaceState) {
         const url = new URL(window.location.href);
         url.search = searchParams.toString();
         window.history.replaceState({}, '', url.toString());
-      } 
+      }
     }
 
     await loadMiloUtils();
-    
+
     // the css gets loaded into the shadow dom
     const cssResponse = await fetch('/web-components/search/blog-search.css');
     const cssText = await cssResponse.text();
     const styleSheet = new CSSStyleSheet();
     await styleSheet.replace(cssText);
-    this.shadowRoot.adoptedStyleSheets = [styleSheet]; 
-    
+    this.shadowRoot.adoptedStyleSheets = [styleSheet];
+
     const placeholders = await fetchPlaceholders();
-    const source = this.getAttribute('data-source') || '/sorted-index/sorted-query-index.json';
-    
-    
-    // Detect if this search should be nav-style
-    const isNavSearch = document.querySelector('header') || this.classList.contains('nav-search');
-    if (isNavSearch) {
+    const source = this.getAttribute('data-source') || DEFAULT_INDEX_SOURCE;
+    this.config = { source, placeholders };
+
+    const isExploreFacets = this.classList.contains('explore-facets')
+      || this.getAttribute('variant') === 'explore';
+    const isNavSearch = !isExploreFacets
+      && (this.classList.contains('nav-search') || !!this.closest('header, .feds-topnav, .feds-nav'));
+
+    if (isExploreFacets) {
+      this.classList.add('explore-facets');
+      const toolbar = document.createElement('div');
+      toolbar.className = 'explore-toolbar';
+
+      const filtersLabel = document.createElement('span');
+      filtersLabel.className = 'explore-filters-label';
+      filtersLabel.textContent = 'Filters:';
+      toolbar.append(filtersLabel);
+
+      const searchWrap = document.createElement('div');
+      searchWrap.className = 'explore-search';
+      const icon = searchIcon();
+      icon.classList.add('explore-search-trigger');
+      icon.setAttribute('role', 'button');
+      icon.setAttribute('tabindex', '0');
+      icon.setAttribute('aria-label', placeholders.searchPlaceholder || 'Search');
+      const input = searchInput(this, { source, placeholders });
+      input.classList.add('explore-search-input');
+      input.hidden = true;
+      const collapseSearch = () => {
+        searchWrap.classList.remove('expanded');
+        input.hidden = true;
+      };
+      const toggleSearch = () => {
+        const expanded = searchWrap.classList.toggle('expanded');
+        input.hidden = !expanded;
+        if (expanded) input.focus();
+      };
+      icon.addEventListener('click', toggleSearch);
+      icon.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggleSearch();
+        }
+      });
+      // Native search clear (X) fires a 'search' event; collapse the field when emptied.
+      input.addEventListener('search', () => {
+        if (input.value === '') {
+          collapseSearch();
+          this.refreshExploreView();
+        }
+      });
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+          input.value = '';
+          collapseSearch();
+          this.refreshExploreView();
+        }
+      });
+      searchWrap.append(icon, input);
+      toolbar.append(searchWrap);
+
+      this.shadowRoot.append(toolbar, exploreResultsContainer(this));
+
+      const articleFeed = document.querySelector('.article-feed');
+      if (articleFeed) {
+        articleFeed.classList.add('explore-facets-suppressed');
+        articleFeed.parentElement?.querySelector('.filter-container')?.classList.add('explore-facets-suppressed');
+        articleFeed.parentElement?.querySelector('.selected-container')?.classList.add('explore-facets-suppressed');
+      }
+    } else if (isNavSearch) {
       this.classList.add('nav-search');
-      
+
       // For nav search, everything goes in Shadow DOM but uses positioning to span full width
       const topNav = document.querySelector('.feds-topnav');
       if (topNav) {
         topNav.classList.add('has-blog-nav-search');
-        
+
         // creates nav-search-container which is important for the positioning
         const searchContainer = document.createElement('div');
         searchContainer.className = 'nav-search-container';
-        
+
         const icon = searchIcon();
         const input = searchInput(this, { source, placeholders });
         const results = searchResultsContainer(this);
-        
+
         // adds all elements to the shadow dom
         searchContainer.append(icon, input, results);
         this.shadowRoot.appendChild(searchContainer);
-        
+
         // Close search on escape key
         input.addEventListener('keydown', (e) => {
           if (e.key === 'Escape') {
@@ -495,8 +660,532 @@ class BlogSearch extends HTMLElement {
     if (typeof decorateIcons === 'function') {
       decorateIcons(this.shadowRoot);
     }
-    
+
+    if (isExploreFacets) {
+      await this.initFacets({ explore: true });
+      return;
+    }
+
+    if (isNavSearch) {
+      fetchData(source).then((data) => {
+        if (data) this.searchIndexData = data;
+      });
+      return;
+    }
+
+    await this.initFacets({ explore: false });
+  }
+
+  async refreshExploreView() {
+    if (!this.allData) return;
+
+    let scopedData = this.allData;
+    if (currentTopic) {
+      scopedData = this.allData.filter((item) => {
+        if (!item.tags) return false;
+        try {
+          const tags = JSON.parse(item.tags);
+          return tags.includes(currentTopic);
+        } catch {
+          return item.tags.includes(currentTopic);
+        }
+      });
+    }
+
+    const queryInput = this.shadowRoot.querySelector('.explore-search-input');
+    const searchValue = queryInput?.value?.trim() || '';
+    let searchTerms = [];
+    let data = scopedData;
+
+    if (searchValue.length >= 3) {
+      searchTerms = searchValue.toLowerCase().split(/\s+/).filter((term) => term.length >= 3);
+      data = filterData(searchTerms, scopedData);
+    }
+
+    const facetFilteredData = this.applyFilters(data, this.activeFilters);
+    const orderedData = searchTerms.length
+      ? facetFilteredData
+      : sortArticlesByPublicationDate(facetFilteredData);
+    this.updateFilterCounts(facetFilteredData);
+    await renderExploreResults(this, this.config, orderedData, searchTerms);
+  }
+
+  applyFilterChange() {
+    if (this.classList.contains('explore-facets')) {
+      this.refreshExploreView();
+      return;
+    }
+    const queryInput = this.shadowRoot.querySelector('input[type="search"]');
+    if (queryInput && queryInput.value.length >= 3) {
+      handleSearch({ target: queryInput }, this, this.config);
+    }
+  }
+
+  async initFacets({ explore }) {
+    const { source } = this.config;
+    this.allData = await fetchData(source);
+    if (!this.allData) {
+      logError('initFacets', `data load failed for ${source}, filter bar skipped`);
+      return;
+    }
+
+    this.activeFilters = this.loadFiltersFromURL();
+    const facets = this.generateFacets(this.allData);
+    this.renderFilterBar(facets, { explore });
+    this.renderChips(this.activeFilters);
+    this.updateFilterCounts(this.allData);
+
+    this.shadowRoot.querySelector('.filter-bar')?.addEventListener('change', (e) => {
+      if (e.target.tagName === 'SELECT') {
+        const { value } = e.target;
+        this.activeFilters.date = value ? [value] : [];
+        this.renderChips(this.activeFilters);
+        this.updateURLState(this.activeFilters);
+        this.applyFilterChange();
+        return;
+      }
+      if (e.target.type !== 'checkbox') return;
+      const { group } = e.target.closest('.filter-dropdown').dataset;
+      const { value } = e.target;
+      if (e.target.checked) {
+        this.activeFilters[group].push(value);
+      } else {
+        this.activeFilters[group] = this.activeFilters[group].filter((v) => v !== value);
+      }
+      this.renderChips(this.activeFilters);
+      this.updateURLState(this.activeFilters);
+      this.applyFilterChange();
+    });
+
+    this.addEventListener('remove-filter', (e) => {
+      const { group, value } = e.detail;
+      this.activeFilters[group] = this.activeFilters[group].filter((v) => v !== value);
+      this.renderChips(this.activeFilters);
+      this.updateURLState(this.activeFilters);
+      this.applyFilterChange();
+    });
+
+    this.addEventListener('clear-all-filters', () => {
+      Object.keys(this.activeFilters).forEach((key) => {
+        this.activeFilters[key] = [];
+      });
+      this.closeFacetPanels(this.shadowRoot.querySelector('.filter-bar'));
+      // Reset the visible controls so the UI matches the cleared state.
+      this.shadowRoot.querySelectorAll('.filter-bar input[type="checkbox"]:checked').forEach((checkbox) => {
+        checkbox.checked = false;
+      });
+      const dateSelect = this.shadowRoot.querySelector('.filter-date-select');
+      if (dateSelect) dateSelect.value = '';
+      const searchField = this.shadowRoot.querySelector('.explore-search-input');
+      if (searchField) {
+        searchField.value = '';
+        searchField.hidden = true;
+      }
+      this.shadowRoot.querySelector('.explore-search')?.classList.remove('expanded');
+      this.renderChips(this.activeFilters);
+      this.updateURLState(this.activeFilters);
+      this.applyFilterChange();
+    });
+
+    if (explore) {
+      await this.refreshExploreView();
+    }
+
+    this.bindOutsideClickClose();
+  }
+
+  bindOutsideClickClose() {
+    if (this.outsideClickHandler) return;
+    this.outsideClickHandler = (e) => {
+      if (e.composedPath().includes(this)) return;
+      this.closeFacetPanels(this.shadowRoot?.querySelector('.filter-bar'));
+    };
+    document.addEventListener('click', this.outsideClickHandler);
+  }
+
+  disconnectedCallback() {
+    if (!this.outsideClickHandler) return;
+    document.removeEventListener('click', this.outsideClickHandler);
+    this.outsideClickHandler = null;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  generateFacets(data) {
+    const catSet = new Set();
+    const prodSet = new Set();
+    const authorSet = new Set();
+    const dateSet = new Set();
+    const typeSet = new Set();
+
+    data.forEach((article) => {
+      if (article.tags) {
+        try {
+          const tags = JSON.parse(article.tags);
+          if (Array.isArray(tags)) {
+            tags.forEach((tag) => {
+              if (tag) catSet.add(tag);
+            });
+          }
+        } catch {
+          // eslint-disable-next-line no-console
+        }
+      }
+      if (article.adobeCloud) prodSet.add(article.adobeCloud);
+      if (article.adobeApp) prodSet.add(article.adobeApp);
+      if (article.author) authorSet.add(article.author);
+      if (article.sortDate) dateSet.add(article.sortDate);
+      if (article.articleType) typeSet.add(article.articleType);
+    });
+
+    const sorted = (set) => [...set].sort();
+
+    return {
+      cat: sorted(catSet),
+      prod: sorted(prodSet),
+      author: sorted(authorSet),
+      date: sorted(dateSet),
+      type: sorted(typeSet),
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  applyFilters(data, activeFilters) {
+    return data.filter((article) => (
+      Object.entries(activeFilters).every(([group, activeValues]) => {
+        if (activeValues.length === 0) return true;
+
+        if (group === 'date') {
+          if (!article.sortDate) return false;
+          const articleDate = new Date(article.sortDate);
+          const now = new Date();
+          const cutoff = new Date(now);
+          const preset = activeValues[0];
+          if (preset === 'last-week') cutoff.setDate(now.getDate() - 7);
+          else if (preset === 'last-month') cutoff.setMonth(now.getMonth() - 1);
+          else if (preset === 'last-year') cutoff.setFullYear(now.getFullYear() - 1);
+          return articleDate >= cutoff;
+        }
+
+        let values = [];
+        switch (group) {
+          case 'cat':
+            if (article.tags) {
+              try {
+                const parsed = JSON.parse(article.tags);
+                if (Array.isArray(parsed)) values = parsed.filter(Boolean);
+              } catch { /* invalid JSON, no match */ }
+            }
+            break;
+          case 'prod':
+            values = [article.adobeCloud, article.adobeApp].filter(Boolean);
+            break;
+          case 'author':
+            if (article.author) values = [article.author];
+            break;
+          case 'type':
+            if (article.articleType) values = [article.articleType];
+            break;
+          default:
+            break;
+        }
+
+        return activeValues.some((v) => values.includes(v));
+      })
+    ));
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  loadFiltersFromURL() {
+    const params = new URLSearchParams(window.location.search);
+    return {
+      cat: params.getAll('cat').filter(Boolean),
+      prod: params.getAll('prod').filter(Boolean),
+      author: params.getAll('author').filter(Boolean),
+      date: params.getAll('date').filter(Boolean),
+      type: params.getAll('type').filter(Boolean),
+    };
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  updateURLState(activeFilters) {
+    const params = new URLSearchParams(window.location.search);
+    const q = params.get('q');
+
+    const newParams = new URLSearchParams();
+
+    if (q) newParams.set('q', q);
+
+    Object.entries(activeFilters).forEach(([group, values]) => {
+      if (values.length > 0) {
+        values.forEach((value) => {
+          newParams.append(group, value);
+        });
+      }
+    });
+
+    const url = new URL(window.location.href);
+    url.search = newParams.toString();
+    window.history.replaceState({}, '', url.toString());
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  closeFacetPanels(filterBar, { exceptToggle = null } = {}) {
+    if (!filterBar) return;
+    filterBar.querySelectorAll('.filter-dropdown-toggle').forEach((toggle) => {
+      if (toggle === exceptToggle) return;
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.parentElement?.querySelector('ul')?.classList.remove('show');
+    });
+    filterBar.querySelector('.filter-date-select')?.blur();
+  }
+
+  renderFilterBar(facets, { explore = false } = {}) {
+    const filterBar = document.createElement('div');
+    filterBar.className = 'filter-bar';
+    if (explore) filterBar.classList.add('filter-bar-explore');
+
+    const labels = explore
+      ? { cat: 'Category', prod: 'Products', type: 'Topic', author: 'Author' }
+      : { cat: 'Category', prod: 'Product', author: 'Author', type: 'Type' };
+    const exploreGroups = new Set(['prod', 'cat', 'type', 'author', 'date']);
+    const facetEntries = explore
+      ? ['prod', 'cat', 'type', 'author', 'date'].map((group) => [group, facets[group]])
+      : Object.entries(facets);
+
+    facetEntries.forEach(([group, values]) => {
+      if (group === 'date') {
+        if (explore && !exploreGroups.has('date')) return;
+        const dateSelect = document.createElement('select');
+        dateSelect.className = 'filter-date-select';
+        dateSelect.setAttribute('aria-label', 'Date');
+        const defaultOption = document.createElement('option');
+        defaultOption.value = '';
+        defaultOption.textContent = 'Date';
+        // In explore mode the select itself acts as the "Date" label, so hide the
+        // placeholder from the open list and offer an explicit "All dates" reset.
+        if (explore) {
+          defaultOption.hidden = true;
+        } else {
+          defaultOption.textContent = 'All dates';
+        }
+        dateSelect.append(defaultOption);
+        if (explore) {
+          const allDatesOption = document.createElement('option');
+          allDatesOption.value = '';
+          allDatesOption.textContent = 'All dates';
+          dateSelect.append(allDatesOption);
+        }
+        [
+          { value: 'last-week', label: 'Last week' },
+          { value: 'last-month', label: 'Last month' },
+          { value: 'last-year', label: 'Last year' },
+        ].forEach(({ value, label }) => {
+          const option = document.createElement('option');
+          option.value = value;
+          option.textContent = label;
+          dateSelect.append(option);
+        });
+        const [activeDate] = this.activeFilters.date;
+        if (explore && activeDate) {
+          dateSelect.value = activeDate;
+        }
+        const closeCustomDropdowns = () => {
+          filterBar.querySelectorAll('.filter-dropdown-toggle[aria-expanded="true"]').forEach((toggle) => {
+            toggle.setAttribute('aria-expanded', 'false');
+            toggle.parentElement?.querySelector('ul')?.classList.remove('show');
+          });
+        };
+        dateSelect.addEventListener('mousedown', closeCustomDropdowns);
+        dateSelect.addEventListener('focus', closeCustomDropdowns);
+        filterBar.append(dateSelect);
+        return;
+      }
+
+      if (explore && !exploreGroups.has(group)) return;
+      if (values.length === 0) return;
+      const toggle = document.createElement('button');
+
+      toggle.className = 'filter-dropdown-toggle';
+      toggle.setAttribute('aria-expanded', 'false');
+      const baseLabel = labels[group] || group;
+      toggle.textContent = baseLabel;
+      // Keep the plain label so we can re-append a selection count later.
+      toggle.dataset.baseLabel = baseLabel;
+
+      const menu = document.createElement('ul');
+
+      values.forEach((value, index) => {
+        const item = document.createElement('li');
+
+        const checkboxId = `filter-${group}-${index}`;
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = checkboxId;
+        checkbox.value = value;
+
+        const label = document.createElement('label');
+        label.setAttribute('for', checkboxId);
+        label.textContent = value;
+
+        item.append(checkbox, label);
+        item.addEventListener('click', (e) => {
+          if (e.target.closest('input[type="checkbox"], label')) return;
+          checkbox.checked = !checkbox.checked;
+          checkbox.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+        menu.append(item);
+      });
+
+      toggle.addEventListener('click', () => {
+        const currentlyOpen = toggle.getAttribute('aria-expanded') === 'true';
+        if (currentlyOpen) {
+          toggle.setAttribute('aria-expanded', 'false');
+          menu.classList.remove('show');
+          return;
+        }
+        this.closeFacetPanels(filterBar);
+        toggle.setAttribute('aria-expanded', 'true');
+        menu.classList.add('show');
+      });
+
+      const dropdown = document.createElement('div');
+      dropdown.className = 'filter-dropdown';
+      // used to identify the group of the filter
+      dropdown.dataset.group = group;
+      dropdown.append(toggle, menu);
+      filterBar.append(dropdown);
+    });
+
+    const toolbar = this.shadowRoot.querySelector('.explore-toolbar');
+    if (explore && toolbar) {
+      const searchWrap = toolbar.querySelector('.explore-search');
+      toolbar.insertBefore(filterBar, searchWrap);
+    } else {
+      this.shadowRoot.append(filterBar);
+    }
+    return filterBar;
+  }
+
+  syncExploreControls(activeFilters) {
+    const filterBar = this.shadowRoot.querySelector('.filter-bar-explore');
+    if (filterBar) {
+      filterBar.querySelectorAll('.filter-dropdown').forEach((dropdown) => {
+        const { group } = dropdown.dataset;
+        const toggle = dropdown.querySelector('.filter-dropdown-toggle');
+        const base = toggle.dataset.baseLabel || toggle.textContent;
+        const count = (activeFilters[group] || []).length;
+        toggle.textContent = count ? `${base} (${count})` : base;
+        toggle.classList.toggle('has-active', count > 0);
+      });
+    }
+
+    const toolbar = this.shadowRoot.querySelector('.explore-toolbar');
+    if (!toolbar) return;
+    let clearBtn = toolbar.querySelector('.explore-clear-all');
+    if (!clearBtn) {
+      clearBtn = document.createElement('button');
+      clearBtn.className = 'filter-clear-all explore-clear-all';
+      clearBtn.textContent = 'Clear all';
+      clearBtn.addEventListener('click', () => {
+        this.dispatchEvent(new CustomEvent('clear-all-filters', { bubbles: true }));
+      });
+      const searchWrap = toolbar.querySelector('.explore-search');
+      toolbar.insertBefore(clearBtn, searchWrap);
+    }
+    const anyActive = Object.values(activeFilters).some((values) => values.length > 0);
+    clearBtn.hidden = !anyActive;
+  }
+
+  renderChips(activeFilters) {
+    // Explore mode shows selection counts on the filter buttons instead of chips.
+    if (this.classList.contains('explore-facets')) {
+      this.syncExploreControls(activeFilters);
+      return;
+    }
+    this.shadowRoot.querySelector('.filter-chips')?.remove();
+    if (!Object.values(activeFilters).some((values) => values.length > 0)) return;
+    const chipsContainer = document.createElement('div');
+    chipsContainer.className = 'filter-chips';
+
+    Object.entries(activeFilters).forEach(([group, values]) => {
+      values.forEach((value) => {
+        const chip = document.createElement('span');
+        chip.className = 'filter-chip';
+        chip.textContent = value;
+
+        const removeButton = document.createElement('button');
+        removeButton.className = 'filter-chip-remove';
+        removeButton.textContent = 'x';
+        removeButton.addEventListener('click', () => {
+          this.dispatchEvent(new CustomEvent('remove-filter', { detail: { group, value }, bubbles: true }));
+        });
+
+        chip.append(removeButton);
+        chipsContainer.append(chip);
+      });
+    });
+
+    const clearButton = document.createElement('button');
+    clearButton.className = 'filter-clear-all';
+    clearButton.textContent = 'Clear all';
+    clearButton.addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('clear-all-filters', { bubbles: true }));
+    });
+    chipsContainer.append(clearButton);
+    const chipsParent = this.classList.contains('explore-facets')
+      ? this.shadowRoot.querySelector('.explore-toolbar')
+      : this.shadowRoot.querySelector('.filter-bar');
+    chipsParent?.append(chipsContainer);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getArticleValues(article, group) {
+    switch (group) {
+      case 'cat':
+        if (article.tags) {
+          try {
+            return JSON.parse(article.tags).filter(Boolean);
+          } catch { /* invalid JSON, no match */ }
+        }
+        return [];
+      case 'prod':
+        return [article.adobeCloud, article.adobeApp].filter(Boolean);
+      case 'author':
+        return article.author ? [article.author] : [];
+      case 'type':
+        return article.articleType ? [article.articleType] : [];
+      default:
+        return [];
+    }
+  }
+
+  updateFilterCounts(data) {
+    // Explore mode keeps option lists clean (names only, no per-option counts).
+    if (this.classList.contains('explore-facets')) return;
+    const filterBar = this.shadowRoot.querySelector('.filter-bar');
+    if (!filterBar) return;
+    const filterDropdowns = filterBar.querySelectorAll('.filter-dropdown');
+    filterDropdowns.forEach((dropdown) => {
+      const { group } = dropdown.dataset;
+
+      dropdown.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+        const { value } = checkbox;
+        const count = data.filter((article) => (
+          this.getArticleValues(article, group).includes(value)
+        )).length;
+
+        const label = checkbox.nextElementSibling;
+        label.textContent = '';
+
+        const textNode = document.createTextNode(`${value} `);
+        const countSpan = document.createElement('span');
+        countSpan.className = 'filter-count';
+        countSpan.textContent = `(${count})`;
+
+        label.append(textNode, countSpan);
+      });
+    });
   }
 }
-
 customElements.define('blog-search', BlogSearch);
+export default BlogSearch;

--- a/web-components/search/blog-search.js
+++ b/web-components/search/blog-search.js
@@ -56,6 +56,16 @@ function getArticleSortTimestamp(article) {
   return 0;
 }
 
+// adobeCloud/adobeApp are authored as comma-separated strings in a single meta
+// tag; split them so each product surfaces as its own facet value.
+function splitProductValues(...fields) {
+  return fields
+    .filter(Boolean)
+    .flatMap((field) => field.split(','))
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
 function comparePathNumbers(a, b) {
   const numbersA = a.match(/\d+/g)?.map(Number) || [];
   const numbersB = b.match(/\d+/g)?.map(Number) || [];
@@ -830,8 +840,8 @@ class BlogSearch extends HTMLElement {
           // eslint-disable-next-line no-console
         }
       }
-      if (article.adobeCloud) prodSet.add(article.adobeCloud);
-      if (article.adobeApp) prodSet.add(article.adobeApp);
+      splitProductValues(article.adobeCloud, article.adobeApp)
+        .forEach((product) => prodSet.add(product));
       if (article.author) authorSet.add(article.author);
       if (article.sortDate) dateSet.add(article.sortDate);
       if (article.articleType) typeSet.add(article.articleType);
@@ -877,7 +887,7 @@ class BlogSearch extends HTMLElement {
             }
             break;
           case 'prod':
-            values = [article.adobeCloud, article.adobeApp].filter(Boolean);
+            values = splitProductValues(article.adobeCloud, article.adobeApp);
             break;
           case 'author':
             if (article.author) values = [article.author];
@@ -1149,7 +1159,7 @@ class BlogSearch extends HTMLElement {
         }
         return [];
       case 'prod':
-        return [article.adobeCloud, article.adobeApp].filter(Boolean);
+        return splitProductValues(article.adobeCloud, article.adobeApp);
       case 'author':
         return article.author ? [article.author] : [];
       case 'type':

--- a/web-components/search/blog-search.js
+++ b/web-components/search/blog-search.js
@@ -514,6 +514,7 @@ function searchBox(component, config) {
  * @typedef {Object} ActiveFilters
  * @property {string[]} cat
  * @property {string[]} prod
+ * @property {string[]} cloud
  * @property {string[]} author
  * @property {string[]} date
  * @property {string[]} type
@@ -525,6 +526,7 @@ class BlogSearch extends HTMLElement {
     this.activeFilters = {
       cat: [],
       prod: [],
+      cloud: [],
       author: [],
       date: [],
       type: [],
@@ -823,6 +825,7 @@ class BlogSearch extends HTMLElement {
   generateFacets(data) {
     const catSet = new Set();
     const prodSet = new Set();
+    const cloudSet = new Set();
     const authorSet = new Set();
     const dateSet = new Set();
     const typeSet = new Set();
@@ -840,8 +843,8 @@ class BlogSearch extends HTMLElement {
           // eslint-disable-next-line no-console
         }
       }
-      splitProductValues(article.adobeCloud, article.adobeApp)
-        .forEach((product) => prodSet.add(product));
+      splitProductValues(article.adobeApp).forEach((product) => prodSet.add(product));
+      splitProductValues(article.adobeCloud).forEach((cloud) => cloudSet.add(cloud));
       if (article.author) authorSet.add(article.author);
       if (article.sortDate) dateSet.add(article.sortDate);
       if (article.articleType) typeSet.add(article.articleType);
@@ -852,6 +855,7 @@ class BlogSearch extends HTMLElement {
     return {
       cat: sorted(catSet),
       prod: sorted(prodSet),
+      cloud: sorted(cloudSet),
       author: sorted(authorSet),
       date: sorted(dateSet),
       type: sorted(typeSet),
@@ -887,7 +891,10 @@ class BlogSearch extends HTMLElement {
             }
             break;
           case 'prod':
-            values = splitProductValues(article.adobeCloud, article.adobeApp);
+            values = splitProductValues(article.adobeApp);
+            break;
+          case 'cloud':
+            values = splitProductValues(article.adobeCloud);
             break;
           case 'author':
             if (article.author) values = [article.author];
@@ -910,6 +917,7 @@ class BlogSearch extends HTMLElement {
     return {
       cat: params.getAll('cat').filter(Boolean),
       prod: params.getAll('prod').filter(Boolean),
+      cloud: params.getAll('cloud').filter(Boolean),
       author: params.getAll('author').filter(Boolean),
       date: params.getAll('date').filter(Boolean),
       type: params.getAll('type').filter(Boolean),
@@ -955,11 +963,23 @@ class BlogSearch extends HTMLElement {
     if (explore) filterBar.classList.add('filter-bar-explore');
 
     const labels = explore
-      ? { cat: 'Category', prod: 'Products', type: 'Topic', author: 'Author' }
-      : { cat: 'Category', prod: 'Product', author: 'Author', type: 'Type' };
-    const exploreGroups = new Set(['prod', 'cat', 'type', 'author', 'date']);
+      ? {
+        cat: 'Tags',
+        prod: 'Products',
+        cloud: 'Adobe Cloud',
+        type: 'Topic',
+        author: 'Author',
+      }
+      : {
+        cat: 'Tags',
+        prod: 'Products',
+        cloud: 'Adobe Cloud',
+        author: 'Author',
+        type: 'Type',
+      };
+    const exploreGroups = new Set(['prod', 'cloud', 'cat', 'type', 'author', 'date']);
     const facetEntries = explore
-      ? ['prod', 'cat', 'type', 'author', 'date'].map((group) => [group, facets[group]])
+      ? ['prod', 'cloud', 'cat', 'type', 'author', 'date'].map((group) => [group, facets[group]])
       : Object.entries(facets);
 
     facetEntries.forEach(([group, values]) => {
@@ -1159,7 +1179,9 @@ class BlogSearch extends HTMLElement {
         }
         return [];
       case 'prod':
-        return splitProductValues(article.adobeCloud, article.adobeApp);
+        return splitProductValues(article.adobeApp);
+      case 'cloud':
+        return splitProductValues(article.adobeCloud);
       case 'author':
         return article.author ? [article.author] : [];
       case 'type':


### PR DESCRIPTION
## Summary

Splits global nav search from in-page explore facet filtering on article listing pages.

- **Nav (`blog-search.nav-search`)** — search typeahead only; no fixed filter bar under the header
- **Explore (`blog-search.explore-facets`)** — injected above `article-feed` with toolbar (Products, Category, Topic, Author, Date + expandable search) and card grid
- **Legacy Milo feed filters** hidden while explore facets are active
- **URL state** — `cat`, `prod`, `type`, `author`, `date`, `q` via `replaceState`
- **UX polish** — accordion dropdowns, full-row filter clicks, chevrons on toggles, richer no-results copy, explore search blue focus, reduced flicker

## Key files

- `web-components/search/blog-search.js`
- `web-components/search/blog-search.css`
- `scripts/scripts.js`